### PR TITLE
Debian Base and xo-server 5.16.0 xo-web 5.16.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     orchestra:
         restart: unless-stopped
-        ezka77/xen-orchestra-ce
+        image: ezka77/xen-orchestra-ce
         container_name: XO_server
         ports:
             - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     orchestra:
         restart: unless-stopped
-        image: local/xen-orchestra-ce
+        ezka77/xen-orchestra-ce
         container_name: XO_server
         ports:
             - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     orchestra:
         restart: unless-stopped
-        image: ezka77/xen-orchestra-ce
+        image: local/xen-orchestra-ce
         container_name: XO_server
         ports:
             - "8000:8000"

--- a/xo-entry.sh
+++ b/xo-entry.sh
@@ -6,6 +6,7 @@ mkdir -p /storage
 chown -R ${USER}:${USER} /storage
 
 # start App
-cd ${USER_HOME}/xo-server
-exec su-exec ${USER} "$@"
+cd ${USER_HOME}/xen-orchestra/packages/xo-server
+"$@"
+#exec su-exec ${USER} "$@"
 

--- a/xo-server.config.yaml
+++ b/xo-server.config.yaml
@@ -89,7 +89,7 @@ http:
 
   # List of files/directories which will be served.
   mounts:
-    '/': '/home/node/xo-web/dist/'
+    '/': '/home/node/xen-orchestra/packages/xo-web/dist/'
 
 #=====================================================================
 


### PR DESCRIPTION
because xen orchestra's git repository changed, docker build's automatic generation did not work anymore.
Unfortunately, I did not manage it with alpine, so here is a push request with a change to debian stretch (as the manufacturer recommends).