### PR TITLE
fix: single file restore wasn't working

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,7 +37,7 @@ RUN /home/node/xen-orchestra/packages/xo-server/link_plugins.sh
 FROM alpine:3.8 as build-libvhdi
 
 WORKDIR /home/node
-RUN apk add --no-cache git g++ make bash automake autoconf libtool gettext-dev pkgconf fuse-dev
+RUN apk add --no-cache git g++ make bash automake autoconf libtool gettext-dev pkgconf fuse-dev fuse
 
 RUN git clone https://github.com/libyal/libvhdi.git
 


### PR DESCRIPTION
the single file restore feature wasn't working due to fuse not being installed on alpine

error message in log was:
Command failed: mount --options=loop,ro --source=/tmp/tmp.../vhdi1 --target=/tmp/tmp-...
mount: /tmp/tmp-7...: failed to setup loop device for /tmp/tmp-.../vhdi1.