### PR TITLE
Allow HTTP/HTTPS configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,54 @@ service as root/superuser and run the docker container with the `privileged`
 flag. The docker-compose file add the SYS_ADMIN capability to the running
 container, this will allow to use NFS mount.
 
+## Environment Variables
+
+Some behaviour of the container can be managed via the following environment variables:
+
+* XO_HTTP_REDIRECTTOHTTPS : Redirect HTTP to HTTPS (default = false)
+* XO_HTTP_LISTEN_PORT : HTTP listen port (default = 8000)
+* XO_HTTPS_LISTEN_PORT : HTTPS listen port (default = unset)
+* XO_HTTPS_LISTEN_CERT : Certificate (in PEM format) for HTTPS (default = './certificate.pem')
+* XO_HTTPS_LISTEN_KEY : Private key (in PEM format) for HTTPS (default = './key.pem')
+* XO_HTTPS_LISTEN_AUTOCERT : Automatically create self-signed certificate if "key" and "cert" are missing (default = true)
+* XO_HTTPS_LISTEN_DHPARAM : DH parameter file for HTTPS (default = unset)
+
+These environment variables can be added to your compose file to enable HTTPS support.
+
+This following example has Xen Orchestra listening on port 80 (HTTP) and port 443 (HTTPS) with automatic self-signed certificates:
+
+```yaml
+services:
+  orchestra:
+    restart: unless-stopped
+    image: ezka77/xen-orchestra-ce:latest
+    container_name: XO_server
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - redis
+    environment:
+      - DEBUG=xo:main
+      - NODE_ENV=production
+      - XOA_PLAN=5
+      - XO_HTTP_REDIRECTTOHTTPS=true
+      - XO_HTTP_LISTEN_PORT=80
+      - XO_HTTPS_LISTEN_PORT=443
+      - XO_HTTPS_LISTEN_AUTOCERT=true
+    #privileged: true
+    # SYS_ADMIN should be enough capability to use NFS mount
+    cap_add:
+      - SYS_ADMIN
+    volumes:
+      - xo-data:/storage
+    logging: &default_logging
+      driver: "json-file"
+      options:
+        max-size: "1M"
+        max-file: "2"
+```
+
 ## Support
 
 * This Docker project is not supported by Xen-Orchestra or the parent company Vates.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,7 +59,6 @@ RUN mkdir -p /home/node
 WORKDIR /home/node
 
 RUN apk add --no-cache \
-  tini \
   su-exec \
   bash \
   util-linux \
@@ -70,10 +69,7 @@ RUN apk add --no-cache \
   cifs-utils \
   openssl
 
-RUN mkdir -p /storage
-
-# configurations
-COPY config.toml /etc/xo-server/config.toml
+RUN mkdir -p /storage /etc/xo-server
 
 # Copy our App from the build container
 COPY --from=build /home/node/xen-orchestra /home/node/xen-orchestra
@@ -92,9 +88,23 @@ COPY healthcheck.js /usr/local/share/healthcheck.js
 HEALTHCHECK --interval=1m --timeout=12s --start-period=30s \  
  CMD /usr/bin/node /usr/local/share/healthcheck.js
 
+# Add remco to image
+ENV REMCO_VER="0.11.1"
+RUN apk add --no-cache ca-certificates && \
+    wget https://github.com/HeavyHorst/remco/releases/download/v${REMCO_VER}/remco_${REMCO_VER}_linux_amd64.zip && \
+    unzip remco_${REMCO_VER}_linux_amd64.zip && rm remco_${REMCO_VER}_linux_amd64.zip && \
+    mv remco_linux /bin/remco
+ADD remco /etc/remco
+
+# Environment vars to control config
+ENV XO_HTTP_LISTEN_PORT="8000" \
+#    XO_HTTP_REDIRECTTOHTTPS="false" \
+#    XO_HTTPS_LISTEN_PORT="443" \
+#    XO_HTTPS_LISTEN_CERT="./certificate.pem" \
+#    XO_HTTPS_LISTEN_KEY="./key.pem" \
+#    XO_HTTPS_LISTEN_AUTOCERT="true" \
+#    XO_HTTPS_LISTEN_DHPARAM="./dhparam.pem
+
 # Run the App
-COPY entrypoint.sh /entrypoint.sh
-EXPOSE 8000
 WORKDIR /home/node/xen-orchestra/packages/xo-server/
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh" ]
-CMD ["./bin/xo-server"]
+CMD ["/bin/remco"]

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/ash
-set -e
-
-# Start rpcbind (used for NFS mount)
-rpcbind
-
-# start app
-exec "$@"

--- a/alpine/healthcheck.js
+++ b/alpine/healthcheck.js
@@ -2,7 +2,7 @@ var http = require("http");
 
 var options = {
     host : "localhost",
-    port : "8000",
+    port : process.env.XO_HTTP_LISTEN_PORT,
     timeout : 2000
 };
 

--- a/alpine/remco/config
+++ b/alpine/remco/config
@@ -1,0 +1,24 @@
+log_level = "debug"
+log_format = "text"
+
+[default_backends]
+[default_backends.env]
+  onetime = true
+  keys = [ "/xo" ]
+
+[[resource]]
+name = "rpcbind"
+
+[resource.exec]
+  command = "rpcbind -f"
+
+[[resource]]
+name = "xo-server"
+
+[resource.exec]
+  command = "./bin/xo-server"
+  kill_timeout = 10
+
+[[resource.template]]
+  src = "/etc/remco/templates/config.toml"
+  dst = "/etc/xo-server/config.toml"

--- a/alpine/remco/templates/config.toml
+++ b/alpine/remco/templates/config.toml
@@ -57,7 +57,7 @@ datadir = '/storage/data'
 [http]
 # If set to true, all HTTP traffic will be redirected to the first HTTPs
 # configuration.
-# redirectToHttps = true
+redirectToHttps = {{ getv("/xo/http/redirecttohttps", "false") }}
 
 # Settings applied to cookies created by xo-server's embedded HTTP server.
 #
@@ -78,7 +78,7 @@ datadir = '/storage/data'
 # Port on which the server is listening on.
 #
 # Default: undefined
-port = 8000
+port = {{ getv("/xo/http/listen/port") }}
 
 # Instead of `host` and `port` a path to a UNIX socket may be specified
 # (overrides `host` and `port`).
@@ -92,29 +92,17 @@ port = 8000
 # # https://nodejs.org/docs/latest/api/tls.html#tls.createServer
 # #
 # # The only difference is the presence of the certificate and the key.
-# [[http.listen]]
-# #hostname = '127.0.0.1'
-# port = 443
-#
-# # File containing the certificate (PEM format).
-# #
-# # If a chain of certificates authorities is needed, you may bundle them
-# # directly in the certificate.
-# #
-# # Note: the order of certificates does matter, your certificate should come
-# # first followed by the certificate of the above
-# # certificate authority up to the root.
-# #
-# # Default: undefined
-# cert = './certificate.pem'
-#
-# # File containing the private key (PEM format).
-# #
-# # If the key is encrypted, the passphrase will be asked at
-# # server startup.
-# #
-# # Default: undefined
-# key = './key.pem'
+
+{% if exists("/xo/https/listen/port") %}
+[[http.listen]]
+port = {{ getv("/xo/https/listen/port") }}
+cert = '{{ getv("/xo/https/listen/cert", "./certificate.pem") }}'
+key = '{{ getv("/xo/https/listen/key", "./key.pem") }}'
+autoCert = {{ getv("/xo/https/listen/autocert", "true") }}
+{% if exists("/xo/https/listen/dhparam") %}
+dhparam = '{{ getv("/xo/https/listen/dhparam") }}'
+{% endif %}
+{% endif %}
 
 # List of files/directories which will be served.
 [http.mounts]


### PR DESCRIPTION
This PR introduces configuration of `/etc/xo-server/config.toml` via [remco](https://github.com/HeavyHorst/remco), a lightweight configuration manager so values such as the HTTP port and enabling HTTPS can be managed by environment variables.

Remco also replaces tini as PID 1 in the container to execute `rpcbind` and `xo-server` and keep them running.

An example for usage has been added to the README and `healthcheck.js` has been updated to use the HTTP env var value for its check.

The naming of the environment variables are loosely based on the names in the `config.toml` for `xo-server`.

This PR also removes `EXPOSE 8000` in the `Dockerfile` as this port is no longer hard coded (although the default is still 8000). 