### PR TITLE
Add netbox plugin

### DIFF
--- a/alpine/link_plugins.sh
+++ b/alpine/link_plugins.sh
@@ -10,6 +10,7 @@ xo-server-auth-ldap \
 xo-server-auth-saml \
 xo-server-backup-reports \
 xo-server-load-balancer \
+xo-server-netbox \
 xo-server-perf-alert \
 xo-server-sdn-controller \
 xo-server-transport-email \


### PR DESCRIPTION
This PR adds the new Netbox plugin that was recently released to the build.

The documentation for this plugin is here: [https://xen-orchestra.com/docs/advanced.html#netbox](https://xen-orchestra.com/docs/advanced.html#netbox)