### PR TITLE
Update patch to reflect upstream URL changes

### DIFF
--- a/alpine/patches/gh_issue_redirect.diff
+++ b/alpine/patches/gh_issue_redirect.diff
@@ -6,7 +6,7 @@ Index: xen-orchestra/packages/xo-web/src/xo-app/about/index.js
                </Row>
                <Row>
                  <Col mediumSize={6}>
--                  <a href='https://github.com/vatesfr/xen-orchestra/issues/new'>
+-                  <a href='https://github.com/vatesfr/xen-orchestra/issues/new/choose'>
 +                  <a href='https://github.com/Ezka77/xen-orchestra-ce'>
                      <Icon icon='bug' size={4} />
                      <h4>{_('bugTracker')}</h4>


### PR DESCRIPTION
URL has [changed upstream](https://github.com/vatesfr/xen-orchestra/commit/4db82f447df0ca5c61af28272792beea180f3734) so patch does not apply, this breaks builds.  Updating the patch resolves this.