### PR TITLE
fix yarn build by not removing .git folder before build

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,12 +15,16 @@ RUN git clone -b master --depth 1 https://github.com/vatesfr/xen-orchestra/
 COPY patches /home/node/xen-orchestra/patches
 RUN cd /home/node/xen-orchestra \
     && git apply patches/gh_issue_redirect.diff \
-    && rm -rf /home/node/xen-orchestra/.git /home/node/xen-orchestra/patches
+    && rm -rf /home/node/xen-orchestra/patches
+
 # build
 WORKDIR /home/node/xen-orchestra
 RUN yarn config set network-timeout 300000
 RUN yarn
 RUN yarn build
+
+## Cleanup .git folder
+RUN rm -rf /home/node/xen-orchestra/.git
 
 ##  ~ Experimental ~
 # clean node_modules steps


### PR DESCRIPTION
yarn build fails with following message
```
...
14.95 xo-server:build: fatal: not a git repository (or any of the parent directories): .git
14.95 xo-server:build: Error: Command failed: git rev-parse --short HEAD
14.95 xo-server:build: fatal: not a git repository (or any of the parent directories): .git
14.95 xo-server:build: 
14.95 xo-server:build:     at genericNodeError (node:internal/errors:984:15)
14.95 xo-server:build:     at wrappedFn (node:internal/errors:538:14)
14.95 xo-server:build:     at checkExecSyncError (node:child_process:891:11)
14.95 xo-server:build:     at execFileSync (node:child_process:927:15)
14.95 xo-server:build:     at Object.<anonymous> (/home/node/xen-orchestra/packages/xo-server/.babelrc.cjs:8:21)
14.95 xo-server:build:     at Module._compile (node:internal/modules/cjs/loader:1469:14)
14.95 xo-server:build:     at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
14.95 xo-server:build:     at Module.load (node:internal/modules/cjs/loader:1288:32)
14.95 xo-server:build:     at Module._load (node:internal/modules/cjs/loader:1104:12)
14.95 xo-server:build:     at Module.require (node:internal/modules/cjs/loader:1311:19) {
14.95 xo-server:build:   status: 128,
...
```

This PR moves the removal of the .git folder in the xen-orchestra project to after the build command and yarn can execute it's build operations again. 

My guess vates changed something in the yarn config.